### PR TITLE
update install.sh and fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ record_twitcast.py是录制twitcast的websocket流的精简脚本
 -ml\|--min-loop-interval|180|最短录制间隔
 -ms\|--min-status|1|开始录制前需要持续检测到开播次数
 -o\|-d\|--output\|--dir|record_video/other|输出目录
--u\|--upload|无|上传网盘,格式为网盘类型重试次数:盘符:路径，网盘类型支持rclone paidupcs onedrive，例如rclone3:vps:record
+-u\|--upload|无|上传网盘,格式为网盘类型重试次数:盘符:路径，网盘类型支持rclone baidupcs onedrive，例如rclone3:vps:record
 -dt\|--delete-type|1|删除本地录像需要成功上传的数量，默认为1，del为强制删除，keep为强制保留，all为需要全部上传成功
 -e\|--except|无|排除转播，格式同录制频道，如-e youtube "UCWCc8tO-uUl_7SJXIKJACMw
 * youtube会限需要--you-cookies(用于监测)与--you-config(用于录制)同时使用

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ record_twitcast.py是录制twitcast的websocket流的精简脚本
 
 </details>
 
-#### 一键安装(谨慎使用)
+#### 一键安装(谨慎使用)【不建议使用root用户安装】
 
 `curl https://raw.githubusercontent.com/lovezzzxxx/liverecord/master/install.sh | bash`  
   * __一键脚本安装后脚本调用方式应为`record/record_new.sh`而非下文示例中的`./record_new.sh`__

--- a/install.sh
+++ b/install.sh
@@ -14,9 +14,9 @@ pip3 install --user --upgrade git+https://github.com/streamlink/streamlink.git
 pip3 install --user --upgrade git+https://github.com/ytdl-org/youtube-dl.git
 pip3 install --user --upgrade git+https://github.com/soimort/you-get.git
 echo 'export PATH=$PATH:/usr/local/bin'>>~/.bashrc #修改默认环境变量，如不希望可以注释掉
-echo 'export PATH=$HOME/.local/bin'>>~/.bashrc #因为加了 --user 参数，所以要再加上一个环境变量使得pip安装的包可以正常运行
+echo 'export PATH=$HOME/.local/bin:$PATH'>>~/.bashrc #因为加了 --user 参数，所以要再加上一个环境变量使得pip安装的包可以正常运行
 export PATH=$PATH:/usr/local/bin
-export PATH=$HOME/.local/bin
+export PATH=$HOME/.local/bin:$PATH
 source ~/.bashrc
 
 #安装go语言环境

--- a/install.sh
+++ b/install.sh
@@ -9,16 +9,20 @@ sudo apt update #更新库
 sudo apt install -y curl ffmpeg git build-essential default-jre unzip python3 python3-pip python3-setuptools #安装所需库
 
 #安装python3相关录制工具
-pip3 install --upgrade git+https://github.com/streamlink/streamlink.git
-pip3 install --upgrade git+https://github.com/ytdl-org/youtube-dl.git
-pip3 install --upgrade git+https://github.com/soimort/you-get.git
+python3 -m pip install --user --upgrade pip
+pip3 install --user --upgrade git+https://github.com/streamlink/streamlink.git
+pip3 install --user --upgrade git+https://github.com/ytdl-org/youtube-dl.git
+pip3 install --user --upgrade git+https://github.com/soimort/you-get.git
 echo 'export PATH=$PATH:/usr/local/bin'>>~/.bashrc #修改默认环境变量，如不希望可以注释掉
+echo 'export PATH=$HOME/.local/bin'>>~/.bashrc #因为加了 --user 参数，所以要再加上一个环境变量使得pip安装的包可以正常运行
 export PATH=$PATH:/usr/local/bin
+export PATH=$HOME/.local/bin
+source ~/.bashrc
 
 #安装go语言环境
 sudo rm -rf $(go env GOROOT) #如果有已经安装的go环境，先卸载，新老版本会有冲突，如不希望可以注释掉
-curl -OJL https://golang.org/dl/go1.17.3.linux-amd64.tar.gz #安装go环境，如不希望可以注释掉
-sudo tar -C /usr/local -xzf go1.17.3.linux-amd64.tar.gz ; rm go1.17.3.linux-amd64.tar.gz
+curl -OJL https://golang.org/dl/go1.17.5.linux-amd64.tar.gz #安装go环境，如不希望可以注释掉
+sudo tar -C /usr/local -xzf go1.17.5.linux-amd64.tar.gz ; rm go1.17.5.linux-amd64.tar.gz
 echo 'export PATH=$PATH:/usr/local/go/bin'>>~/.bashrc #修改默认环境变量，如不希望可以注释掉
 export PATH=$PATH:/usr/local/go/bin
 

--- a/install.sh
+++ b/install.sh
@@ -1,47 +1,57 @@
+
+mkdir liverecord #新建liverecord的安装目录
+
+cur_dir="$(pwd)" #定义当前路径
+
 [[ -d livedl ]] || [[ -f livedl ]] && echo "请使用`sudo rm -rf livedl`指令删除livedl文件或文件夹后重试" && exit 1 #git clone需要空文件夹
 
 sudo apt update #更新库
-sudo apt -y install curl #安装curl
-sudo apt -y install ffmpeg #安装ffmpeg
+sudo apt install -y curl ffmpeg git build-essential default-jre unzip python3 python3-pip python3-setuptools #安装所需库
 
-#安装python3相关下载工具
-sudo apt -y install python3 ; sudo apt -y install python3-pip ; sudo apt -y install python3-setuptools #安装python3
-pip3 install --upgrade git+https://github.com/streamlink/streamlink.git ; pip3 install --upgrade git+https://github.com/ytdl-org/youtube-dl.git ; pip3 install --upgrade git+https://github.com/soimort/you-get.git #安装基于python3的下载工具
+#安装python3相关录制工具
+pip3 install --upgrade git+https://github.com/streamlink/streamlink.git
+pip3 install --upgrade git+https://github.com/ytdl-org/youtube-dl.git
+pip3 install --upgrade git+https://github.com/soimort/you-get.git
 echo 'export PATH=$PATH:/usr/local/bin'>>~/.bashrc #修改默认环境变量，如不希望可以注释掉
 export PATH=$PATH:/usr/local/bin
 
-#安装go相关下载工具
+#安装go语言环境
 sudo rm -rf $(go env GOROOT) #如果有已经安装的go环境，先卸载，新老版本会有冲突，如不希望可以注释掉
-wget https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz #安装go环境，如不希望可以注释掉
-sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz ; rm go1.16.5.linux-amd64.tar.gz
+curl -OJL https://golang.org/dl/go1.17.3.linux-amd64.tar.gz #安装go环境，如不希望可以注释掉
+sudo tar -C /usr/local -xzf go1.17.3.linux-amd64.tar.gz ; rm go1.17.3.linux-amd64.tar.gz
 echo 'export PATH=$PATH:/usr/local/go/bin'>>~/.bashrc #修改默认环境变量，如不希望可以注释掉
 export PATH=$PATH:/usr/local/go/bin
-sudo apt -y install git ; sudo apt -y install build-essential
+
+#编译安装livedl
+cd ${cur_dir}
 echo "此处可能需要较长时间，请耐心等待"
 git clone https://github.com/nnn-revo2012/livedl.git ; 
-if [ ! -d "/livedl" ]; then
+if [ ! -d "livedl" ]; then
     echo "livedl 项目文件夹不存在，请确认该项目的github仓库 https://github.com/nnn-revo2012/livedl 是否被删除"
     exit 1
 else
-    cd livedl/src ; go build -o livedl livedl.go ; rm -r `ls | grep -v "^livedl$"` ; cd ../../ #编译安装livedl
+    cd livedl/src ; go build -o livedl livedl.go ; rm -r `ls | grep -v "^livedl$"`
 fi
 
-#安装java相关下载工具
-apt -y install default-jre
-apt -y install unzip
-mkdir BilibiliLiveRecorder ; cd BilibiliLiveRecorder ; wget https://github.com/nICEnnnnnnnLee/BilibiliLiveRecorder/releases/download/V2.14.0/BilibiliLiveRecord.v2.14.0.zip ; unzip BilibiliLiveRecord.v2.14.0.zip ; rm BilibiliLiveRecord.v2.14.0.zip ; cd ..
+#安装BilibiliLiveRecorder
+cd ${cur_dir}
+mkdir BilibiliLiveRecorder ; cd BilibiliLiveRecorder ; 
+curl -OJL https://github.com/nICEnnnnnnnLee/BilibiliLiveRecorder/releases/download/V2.15.0/BilibiliLiveRecord.v2.15.0.zip ; unzip BilibiliLiveRecord.v2.15.0.zip
+rm BilibiliLiveRecord.v2.15.0.zip
 
-#下载文件并赋予权限
+#下载录制脚本并赋予权限
+cd ${cur_dir}
 mkdir record
-wget -O "record/record.sh" "https://raw.githubusercontent.com/lovezzzxxx/liverecord/master/record.sh" ; chmod +x record/record.sh
-wget -O "record/record_new.sh" "https://raw.githubusercontent.com/lovezzzxxx/liverecord/master/record_new.sh" ; chmod +x record/record_new.sh
-wget -O "record/record_twitcast.py" "https://raw.githubusercontent.com/lovezzzxxx/liverecord/master/record_twitcast.py" ; chmod +x "record/record_twitcast.py"
+curl https://raw.githubusercontent.com/lovezzzxxx/liverecord/master/record.sh > record/record.sh ; chmod +x record/record.sh
+curl https://raw.githubusercontent.com/lovezzzxxx/liverecord/master/record_new.sh > record/record_new.sh ; chmod +x record/record_new.sh
+curl https://raw.githubusercontent.com/lovezzzxxx/liverecord/master/record_twitcast.py > record/record_twitcast.py; chmod +x record/record_twitcast.py
 
 #配置自动上传
+cd ${cur_dir}
 curl https://rclone.org/install.sh | bash #配置rclone自动上传
-sudo wget https://raw.githubusercontent.com/MoeClub/OneList/master/OneDriveUploader/amd64/linux/OneDriveUploader -P /usr/local/bin/ #配置onedrive自动上传
+sudo curl -O https://raw.githubusercontent.com/MoeClub/OneList/master/OneDriveUploader/amd64/linux/OneDriveUploader -o /usr/local/bin #配置onedrive自动上传
 sudo chmod +x /usr/local/bin/OneDriveUploader
-go get github.com/qjfoidnh/BaiduPCS-Go #配置百度云自动上传
+go install github.com/qjfoidnh/BaiduPCS-Go@latest #配置百度云自动上传
 echo 'export PATH=$PATH:'`echo ~`'/go/bin'>>~/.bashrc #修改默认环境变量，如不希望可以注释掉
 source ~/.bashrc
 

--- a/record.sh
+++ b/record.sh
@@ -4,7 +4,7 @@ if [[ ! -n "${1}" ]]; then
 	echo "${0} youtube|youtubeffmpeg|twitcast|twitcastffmpeg|twitcastpy|twitch|openrec|nicolv[:用户名,密码]|nicoco[:用户名,密码]|nicoch[:用户名,密码]|mirrativ|reality|17live|chaturbate|bilibili|bilibiliproxy[,代理ip:代理端口]|bilibilir|bilibiliproxyr[,代理ip:代理端口]|streamlink|m3u8 \"频道号码\" [best|其他清晰度] [loop|once|视频分段时间] [10,10,1|循环检测间隔,最短录制间隔,录制开始所需连续检测开播次数] [\"record_video/other|其他本地目录\"] [nobackup|rclone:网盘名称:|onedrive|baidupan[重试次数][keep|del]] [\"noexcept|排除转播的youtube频道号码\"] [\"noexcept|排除转播的twitcast频道号码\"] [\"noexcept|排除转播的twitch频道号码\"] [\"noexcept|排除转播的openrec频道号码\"] [\"noexcept|排除转播的nicolv频道号码\"] [\"noexcept|排除转播的nicoco频道号码\"] [\"noexcept|排除转播的nicoch频道号码\"] [\"noexcept|排除转播的mirrativ频道号码\"] [\"noexcept|排除转播的reality频道号码\"] [\"noexcept|排除转播的17live频道号码\"] [\"noexcept|排除转播的chaturbate频道号码\"] [\"noexcept|排除转播的streamlink支持的频道网址\"]"
 	echo "示例：${0} bilibiliproxy,127.0.0.1:1080 \"12235923\" best,1080p60,1080p,720p,480p,360p,worst 14400 15,5,2 \"record_video/mea_bilibili\" rclone:vps:onedrivebaidupan3keep \"UCWCc8tO-uUl_7SJXIKJACMw\" \"kaguramea\" \"kagura0mea\" \"KaguraMea\" "
 	echo "必要模块为curl、streamlink、ffmpeg，可选模块为livedl、python3、you-get，请将livedl文件放置于运行时目录的livedl文件夹内、请将BilibiliLiveRecorder解压放置于运行时目录的BilibiliLiveRecorder文件夹内、请将record_twitcast.py文件放置于运行时目录的record文件夹内。"
-	echo "rclone上传基于\"https://github.com/rclone/rclone\"，onedrive上传基于\"https://github.com/MoeClub/OneList/tree/master/OneDriveUploader\"，百度云上传基于\"https://github.com/iikira/BaiduPCS-Go\"，请登录后使用。"
+	echo "rclone上传基于\"https://github.com/rclone/rclone\"，onedrive上传基于\"https://github.com/MoeClub/OneList/tree/master/OneDriveUploader\"，百度云上传基于\"https://github.com/qjfoidnh/BaiduPCS-Go\"，请登录后使用。"
 	echo "注意使用youtube直播仅支持1080p以下的清晰度，请不要使用best和1080p60及以上的参数"
 	echo "仅bilibili支持排除转播功能"
 	exit 1

--- a/record_new.sh
+++ b/record_new.sh
@@ -35,7 +35,7 @@ if [[ ! -n "${1}" ]]; then
 	echo ""
 	echo "其他说明："
 	echo "必要模块为curl streamlink ffmpeg ,可选模块为livedl python3 you-get,请将livedl文件放置于运行时目录的livedl文件夹内 ,请将BilibiliLiveRecorder解压放置于运行时目录的BilibiliLiveRecorder文件夹内,请将record_twitcast.py文件放置于运行时目录的record文件夹内。"
-	echo "rclone上传基于\"https://github.com/rclone/rclone\"百度云上传基于\"https://github.com/iikira/BaiduPCS-Go\",onedrive上传基于\"https://github.com/MoeClub/OneList/tree/master/OneDriveUploader\",请登录后使用。"
+	echo "rclone上传基于\"https://github.com/rclone/rclone\"百度云上传基于\"https://github.com/qjfoidnh/BaiduPCS-Go\",onedrive上传基于\"https://github.com/MoeClub/OneList/tree/master/OneDriveUploader\",请登录后使用。"
 	echo ""
 	echo ""
 	exit 1


### PR DESCRIPTION
- 多打了个斜杠导致没识别出来文件夹 https://github.com/lovezzzxxx/liverecord/issues/67

- 把这些安装的东西都放在一个文件夹 `liverecord` 里，不然太乱了

- go 1.17 以后的版本中 `go get` 安装二进制的功能被废除，只能使用 `go install`

- 尽量不写 `cd ..` ，用 `cur_dir="$(pwd)"` `cd ${cur_dir}` 来定位路径，避免错误后被 `cd ..` 带到奇怪的路径导致问题

- 用更加现代化的 `curl` 替换 `wget`

- 整理了一下安装脚本，把一些依赖放在一起安装，并且清理未使用的依赖

- 使用 root 用户安装 pip 依赖的时候会有问题，加上 `--user` 参数